### PR TITLE
Delay crossfade unbinding for smoother fade out

### DIFF
--- a/src/components/audioEngine/crossfader.logic.ts
+++ b/src/components/audioEngine/crossfader.logic.ts
@@ -98,9 +98,6 @@ export function hijackMediaElementForCrossfade() {
     }
 
     setTimeout(() => {
-        if (typeof unbindCallback === 'function') {
-            unbindCallback();
-        }
         // This destroys the wavesurfer on the fade out track when the new track starts
         destroyWaveSurferInstance();
         prevNextDisable(false);
@@ -114,6 +111,7 @@ export function hijackMediaElementForCrossfade() {
         xfadeGainNode.gain.linearRampToValueAtTime(0, masterAudioOutput.audioContext.currentTime + 1);
         setTimeout(() => {
             // Clean up and destroy the xfade MediaElement here
+            unbindCallback();
             xfadeGainNode.disconnect();
             delayNode.disconnect();
             hijackedPlayer.remove();


### PR DESCRIPTION
## Summary
- remove early `unbindCallback` during crossfade
- move `unbindCallback` to delayed cleanup before disconnecting gain and delay nodes

## Testing
- `npm test` *(fails: cardBuilderUtils.test.ts)*
- `npx eslint src/components/audioEngine/crossfader.logic.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aba67aa4648324aa98018a8037fdf2