### PR TITLE
Remove duplicate playback visualizer controls

### DIFF
--- a/src/components/playbackSettings/playbackSettings.template.html
+++ b/src/components/playbackSettings/playbackSettings.template.html
@@ -60,24 +60,6 @@
         </label>
         <div class="fieldDescription checkboxFieldDescription">${DisableVbrAudioEncodingHelp}</div>
     </div>
-
-            <div class="sliderContainer-settings sliderContainer-withDescription">
-                <div class="sliderContainer">
-                    <input is="emby-slider" id="sliderButterchurnPresetInterval" label="${ButterchurnPresetInterval}" type="range"
-                        step="1" min="10" max="120" />
-                </div>
-                <div class="fieldDescription">${ButterchurnPresetIntervalHelp}</div>
-            </div>
-            <label class="checkboxContainer">
-                <input type="checkbox" is="emby-checkbox" class="chkEnableFrequencyAnalyzer" />
-                <span>${EnableFrequencyAnalyzer}</span>
-            </label>
-            <label class="checkboxContainer">
-                <input type="checkbox" is="emby-checkbox" class="chkEnableWavesurfer" />
-                <span>${EnableWavesurfer}</span>
-            </label>
-        </div>
-
         <div class="qualitySections hide">
             <div class="verticalSection verticalSection-extrabottompadding videoQualitySection hide">
                 <h2 class="sectionTitle">


### PR DESCRIPTION
## Summary
- remove duplicate Butterchurn preset interval slider and visualizer checkboxes from playback settings template

## Testing
- `npm test` *(fails: expected 5.9999999988 to deeply equal 7.0000000000021)*
- `npm run lint` *(fails: 139 problems, 41 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abaf1785848324a15ea2998cf7f7f2