### PR TITLE
feat: color-adaptive wavesurfer visualizer

### DIFF
--- a/src/components/visualizer/WaveSurferOptions.ts
+++ b/src/components/visualizer/WaveSurferOptions.ts
@@ -1,168 +1,125 @@
 import { WaveSurferOptions } from 'wavesurfer.js';
 
-const color = {
-    progressLeft: 'rgb(20, 160, 160)',
-    progressRight: 'rgb(160, 20, 160)',
-    waveLeft: 'rgb(0, 180, 180)',
-    waveRight: 'rgb(180, 0, 180)',
-    cursor: 'rgb(25, 213, 11)',
-    black: 'rgb(10, 10, 10)',
-    transparentBlack: 'rgba(0, 0, 0, 0.7)',
-    white: 'rgb(251, 251, 251)',
-    transparentWhite: 'rgba(255, 255, 255, 0.7)'
+export interface WaveSurferColorScheme {
+    left: string
+    right: string
+    cursor: string
+}
+
+export const DEFAULT_WAVESURFER_COLORS: WaveSurferColorScheme = {
+    left: 'rgb(0, 180, 180)',
+    right: 'rgb(180, 0, 180)',
+    cursor: 'rgb(25, 213, 11)'
 };
 
-const barStyles = {
-    wholeSongWhite: [
-        {
-            height: 'auto',
-            waveColor: color.transparentBlack,
-            progressColor: color.black,
-            barAlign: undefined
-        },
-        {
-            overlay: true,
-            height: 'auto',
-            waveColor: color.transparentWhite,
-            progressColor: color.white,
-            barAlign: undefined
-        }
-    ],
-    coloredCenteredOverlay: [
-        {
-            height: 'auto',
-            waveColor: color.waveLeft,
-            progressColor: color.progressLeft,
-            barAlign: undefined
-        },
-        {
-            height: 'auto',
-            overlay: true,
-            waveColor: color.waveRight,
-            progressColor: color.progressRight,
-            barAlign: undefined
-        }
-    ],
-    coloredBottomOverlay: [
-        {
-            height: 'auto',
-            waveColor: color.waveLeft,
-            progressColor: color.progressLeft,
-            barAlign: 'bottom'
-        },
-        {
-            height: 'auto',
-            overlay: true,
-            waveColor: color.waveRight,
-            progressColor: color.progressRight,
-            barAlign: 'bottom'
-        }
-    ],
-    joinedColorNoOverlay: [
-        {
-            height: 'auto',
-            waveColor: color.waveLeft,
-            progressColor: color.progressLeft,
-            barAlign: 'bottom'
-        },
-        {
-            height: 'auto',
-            waveColor: color.waveRight,
-            progressColor: color.progressRight,
-            barAlign: 'top'
-        }
-    ],
-    splitColored: [
-        {
-            height: 'auto',
-            waveColor: color.waveLeft,
-            progressColor: color.progressLeft,
-            barAlign: 'bottom'
-        },
-        {
-            height: 'auto',
-            waveColor: color.waveRight,
-            progressColor: color.progressRight,
-            barAlign: 'top'
-        }
-    ],
-    splitColoredCentered:
-    [
-        {
-            height: 'auto',
-            waveColor: color.waveLeft,
-            progressColor: color.progressLeft,
-            barAlign: undefined
-        },
-        {
-            height: 'auto',
-            waveColor: color.waveRight,
-            progressColor: color.progressRight,
-            barAlign: undefined
-        }
-    ]
-};
+export function createWaveSurferChannelStyle(colors: WaveSurferColorScheme) {
+    const barStyles = {
+        joinedColorNoOverlay: [
+            {
+                height: 'auto',
+                waveColor: colors.left,
+                progressColor: colors.left
+            },
+            {
+                height: 'auto',
+                waveColor: colors.right,
+                progressColor: colors.right
+            }
+        ],
+        splitColored: [
+            {
+                height: 'auto',
+                waveColor: colors.left,
+                progressColor: colors.left
+            },
+            {
+                height: 'auto',
+                waveColor: colors.right,
+                progressColor: colors.right
+            }
+        ],
+        splitColoredCentered: [
+            {
+                height: 'auto',
+                waveColor: colors.left,
+                progressColor: colors.left
+            },
+            {
+                height: 'auto',
+                waveColor: colors.right,
+                progressColor: colors.right
+            }
+        ],
+        coloredCenteredOverlay: [
+            {
+                height: 'auto',
+                waveColor: colors.left,
+                progressColor: colors.left
+            },
+            {
+                height: 'auto',
+                overlay: true,
+                waveColor: colors.right,
+                progressColor: colors.right
+            }
+        ]
+    };
 
-const waveSurferChannelStyle = {
-    showDoubleChannels: {
-        barWidth: undefined,
-        barGap: undefined,
-        cursorColor: color.cursor,
-        cursorWidth: 1,
-        autoScroll: true,
-        autoCenter: true,
-        dragToSeek: false,
-        interact: true,
-        sampleRate: 6000,
-        splitChannels: barStyles.splitColoredCentered
-    } as Partial<WaveSurferOptions>,
-    showSingleChannel: {
-        barWidth: 2,
-        barGap: 1,
-        cursorColor: color.cursor,
-        cursorWidth: 1,
-        autoScroll: true,
-        autoCenter: true,
-        dragToSeek: false,
-        interact: true,
-        sampleRate: 6000,
-        splitChannels: barStyles.splitColored } as Partial<WaveSurferOptions>,
-    showWholeSong: {
-        cursorColor: color.cursor,
-        cursorWidth: 1,
-        autoScroll: true,
-        autoCenter: true,
-        sampleRate: 3000,
-        interact: true,
-        dragToSeek: false,
-        barWidth: undefined,
-        barGap: undefined,
-        splitChannels: barStyles.joinedColorNoOverlay } as Partial<WaveSurferOptions>,
-    bar: {
-        barWidth: 4,
-        barGap: 2,
-        cursorColor: color.cursor,
-        cursorWidth: 18,
-        autoScroll: false,
-        autoCenter: false,
-        sampleRate: 6000,
-        minPxPerSec: 1,
-        interact: true,
-        dragToSeek: false,
-        splitChannels: barStyles.coloredCenteredOverlay } as Partial<WaveSurferOptions>,
-    map: {
-        barWidth: 2,
-        barGap: 1,
-        cursorColor: color.cursor,
-        cursorWidth: 1,
-        autoScroll: false,
-        autoCenter: false,
-        sampleRate: 3000,
-        minPxPerSec: 1,
-        interact: true,
-        dragToSeek: true,
-        splitChannels: barStyles.coloredCenteredOverlay } as Partial<WaveSurferOptions>
-};
+    return {
+        showDoubleChannels: {
+            cursorColor: colors.cursor,
+            cursorWidth: 1,
+            autoScroll: true,
+            autoCenter: true,
+            dragToSeek: false,
+            interact: true,
+            sampleRate: 6000,
+            splitChannels: barStyles.splitColoredCentered
+        } as Partial<WaveSurferOptions>,
+        showSingleChannel: {
+            cursorColor: colors.cursor,
+            cursorWidth: 1,
+            autoScroll: true,
+            autoCenter: true,
+            dragToSeek: false,
+            interact: true,
+            sampleRate: 6000,
+            splitChannels: barStyles.splitColored
+        } as Partial<WaveSurferOptions>,
+        showWholeSong: {
+            cursorColor: colors.cursor,
+            cursorWidth: 1,
+            autoScroll: true,
+            autoCenter: true,
+            sampleRate: 3000,
+            interact: true,
+            dragToSeek: false,
+            splitChannels: barStyles.joinedColorNoOverlay
+        } as Partial<WaveSurferOptions>,
+        bar: {
+            cursorColor: colors.cursor,
+            cursorWidth: 18,
+            autoScroll: false,
+            autoCenter: false,
+            sampleRate: 6000,
+            minPxPerSec: 1,
+            interact: true,
+            dragToSeek: false,
+            splitChannels: barStyles.coloredCenteredOverlay
+        } as Partial<WaveSurferOptions>,
+        map: {
+            cursorColor: colors.cursor,
+            cursorWidth: 1,
+            autoScroll: false,
+            autoCenter: false,
+            sampleRate: 3000,
+            minPxPerSec: 1,
+            interact: true,
+            dragToSeek: true,
+            splitChannels: barStyles.coloredCenteredOverlay
+        } as Partial<WaveSurferOptions>
+    };
+}
 
 const surferOptions = {
     container: '#inputSurfer',
@@ -187,7 +144,7 @@ const waveSurferPluginOptions = {
         primaryLabelInterval: 30,
         secondaryLabelInterval: 5
     },
-    zoomOptions:  {
+    zoomOptions: {
         scale: 0.25,
         maxZoom: 8000,
         deltaThreshold: 10,
@@ -195,4 +152,5 @@ const waveSurferPluginOptions = {
     }
 };
 
-export { surferOptions, waveSurferChannelStyle, waveSurferPluginOptions };
+export { surferOptions, waveSurferPluginOptions };
+


### PR DESCRIPTION
## Summary
- adapt WaveSurfer color scheme from album art
- render smooth waveforms instead of bars

## Testing
- `npm test` *(fails: expected 5.9999999988 to deeply equal 7.0000000000021)*
- `npm run lint` *(no output)*
- `npm run stylelint` *(fails: Expected single space after ">" etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68abb73cb594832491e59cac7d5eb41c