### PR TITLE
Preload waveform data for upcoming tracks

### DIFF
--- a/src/components/playback/playbackmanager.js
+++ b/src/components/playback/playbackmanager.js
@@ -27,7 +27,7 @@ import { AppFeature } from 'constants/appFeature';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
 import { MediaError } from 'types/mediaError';
 import { getMediaError } from 'utils/mediaError';
-import { destroyWaveSurferInstance } from 'components/visualizer/WaveSurfer';
+import { destroyWaveSurferInstance, preloadWaveform } from 'components/visualizer/WaveSurfer';
 import { hijackMediaElementForCrossfade, timeRunningOut, xDuration } from 'components/audioEngine/crossfader.logic';
 import { prefetchNextItemImages } from 'components/sitbackMode/sitback.logic';
 import { toApi } from 'utils/jellyfin-apiclient/compat';
@@ -2906,6 +2906,7 @@ export class PlaybackManager {
 
               // Update to point to the new upcoming track
               link.href = mediaUrl;
+              preloadWaveform(mediaUrl);
             }
 
             prefetchNextItemImages(self._playQueueManager);

--- a/src/components/visualizer/WaveSurfer.ts
+++ b/src/components/visualizer/WaveSurfer.ts
@@ -41,6 +41,35 @@ const purgatory: WaveSurfer[] = [];
 
 let lastTouchMoveTime = 0;
 
+const waveformCache = new Map<string, { peaks: number[][]; duration: number }>();
+
+function preloadWaveform(url: string) {
+    if (!visualizerSettings.waveSurfer.enabled || waveformCache.has(url)) return;
+
+    const container = document.createElement('div');
+    container.style.display = 'none';
+    document.body.appendChild(container);
+
+    const ws = WaveSurfer.create({
+        ...surferOptions,
+        container,
+        url,
+        interact: false,
+        autoplay: false
+    });
+
+    ws.once('ready', (duration: number) => {
+        waveformCache.set(url, { peaks: ws.exportPeaks(), duration });
+        ws.destroy();
+        container.remove();
+    });
+
+    ws.once('error', () => {
+        ws.destroy();
+        container.remove();
+    });
+}
+
 function findElements() {
     inputSurfer = document.getElementById('inputSurfer');
     simpleSlider = document.getElementById('simpleSlider');
@@ -52,7 +81,7 @@ function isNewSong(newSongDuration: number) {
     return (newSongDuration !== Math.floor(savedDuration * 10000000));
 }
 
-function waveSurferInitialization(container: string, legacy: WaveSurferLegacy, newSongDuration: 0 ) {
+function waveSurferInitialization(container: string, legacy: WaveSurferLegacy, newSongDuration: number = 0) {
     findElements();
 
     destroyWaveSurferInstance();
@@ -71,26 +100,29 @@ function waveSurferInitialization(container: string, legacy: WaveSurferLegacy, n
         return;
     }
 
+    const cache = waveformCache.get(mediaElement.src);
     const newSong = isNewSong(newSongDuration);
 
     waveSurferInstance = WaveSurfer.create({ ...surferOptions,
         media: mediaElement,
         container: container,
-        peaks: newSong ? undefined : savedPeaks,
-        duration: newSong ? undefined : savedDuration
+        peaks: cache ? cache.peaks : newSong ? undefined : savedPeaks,
+        duration: cache ? cache.duration : newSong ? undefined : savedDuration
     });
 
-    waveSurferInstance.on('zoom', (minPxPerSec)=>{
+    waveSurferInstance.on('zoom', (minPxPerSec: number) => {
         if (mobileTouch) return;
         initializeStyle(minPxPerSec);
 
         currentZoom = minPxPerSec;
     });
 
-    waveSurferInstance.once('ready', (duration) => {
+    waveSurferInstance.once('ready', (duration: number) => {
         setVisibility();
-        savedDuration = duration;
-        if (newSong) {
+        savedDuration = cache?.duration || duration;
+        if (cache) {
+            savedPeaks = cache.peaks;
+        } else if (newSong) {
             savedPeaks = waveSurferInstance.exportPeaks();
         } else {
             const newPeaks = waveSurferInstance.exportPeaks();
@@ -250,5 +282,6 @@ export {
     waveSurferInitialization,
     waveSurferInstance,
     destroyWaveSurferInstance,
-    currentZoom
+    currentZoom,
+    preloadWaveform
 };


### PR DESCRIPTION
## Summary
- cache and reuse waveform peaks for preloaded audio
- preload waveform when preparing next track
- type annotate wavesurfer events and resolve package lock conflict

## Testing
- `npm test` *(fails: cardBuilderUtils tests)*
- `npm run lint` *(fails: 45 errors, 98 warnings)*
- `npm run build:check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abb7eaac20832486b1729409ca0d59