### PR TITLE
Reduce Butterchurn blur on touch devices

### DIFF
--- a/src/components/sitbackMode/sitback.logic.ts
+++ b/src/components/sitbackMode/sitback.logic.ts
@@ -83,3 +83,41 @@ export function triggerSongInfoDisplay() {
         endTransition();
     }, (sitbackSettings.songInfoDisplayDurationInSeconds * 1000));
 }
+
+// Enable lighter Butterchurn blur after inactivity on touch devices
+if ('ontouchstart' in window) {
+    let lastInput = Date.now();
+    let isIdle = false;
+
+    const showCursor = () => {
+        if (isIdle) {
+            isIdle = false;
+            document.body.classList.remove('mouseIdle');
+        }
+    };
+
+    const hideCursor = () => {
+        if (!isIdle) {
+            isIdle = true;
+            document.body.classList.add('mouseIdle');
+            scrollToActivePlaylistItem();
+        }
+    };
+
+    const pointerActivity = () => {
+        lastInput = Date.now();
+        showCursor();
+    };
+
+    const moveEvent = ('PointerEvent' in window) ? 'pointermove' : 'mousemove';
+    const downEvent = ('PointerEvent' in window) ? 'pointerdown' : 'mousedown';
+
+    document.addEventListener(moveEvent, pointerActivity, { passive: true });
+    document.addEventListener(downEvent, pointerActivity, { passive: true });
+
+    setInterval(() => {
+        if (!isIdle && Date.now() - lastInput >= 5000) {
+            hideCursor();
+        }
+    }, 1000);
+}


### PR DESCRIPTION
## Summary
- revert previous merge with master to start from clean branch
- lighten Butterchurn blur on touch devices by tracking pointer activity and toggling `mouseIdle` after inactivity

## Testing
- `npm test`
- `npx eslint src/components/sitbackMode/sitback.logic.ts` *(terminated: process hung)*
- `npm run build:production` *(timed out before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68aba8e2496483248b302da722defe88