### PR TITLE
Reduce Butterchurn blur on touch devices

### DIFF
--- a/src/components/sitbackMode/sitback.logic.ts
+++ b/src/components/sitbackMode/sitback.logic.ts
@@ -83,3 +83,42 @@ export function triggerSongInfoDisplay() {
         endTransition();
     }, (sitbackSettings.songInfoDisplayDurationInSeconds * 1000));
 }
+
+// Mirror desktop's Butterchurn blur easing on touch devices
+if ('ontouchstart' in window) {
+    let lastInput = Date.now();
+    let isIdle = false;
+
+    const showCursor = () => {
+        if (isIdle) {
+            isIdle = false;
+            document.body.classList.remove('mouseIdle');
+        }
+    };
+
+    const hideCursor = () => {
+        if (!isIdle) {
+            isIdle = true;
+            document.body.classList.add('mouseIdle');
+            scrollToActivePlaylistItem();
+        }
+    };
+
+    const pointerActivity = () => {
+        lastInput = Date.now();
+        showCursor();
+    };
+
+    const moveEvent = ('PointerEvent' in window) ? 'pointermove' : 'mousemove';
+    const downEvent = ('PointerEvent' in window) ? 'pointerdown' : 'mousedown';
+
+    document.addEventListener(moveEvent, pointerActivity, { passive: true });
+    document.addEventListener(downEvent, pointerActivity, { passive: true });
+
+    setInterval(() => {
+        if (!isIdle && Date.now() - lastInput >= 5000) {
+            hideCursor();
+        }
+    }, 1000);
+}
+


### PR DESCRIPTION
## Summary
- lighten Butterchurn blur on touch devices by tracking pointer activity in sitback mode and toggling `mouseIdle` after 5 s of inactivity
- document the blur easing behavior for touch layouts

## Testing
- `npm test` *(fail: expected 5.9999999988 to deeply equal 7.0000000000021, etc.)*
- `npx eslint src/components/sitbackMode/sitback.logic.ts`
- `npm run build:production` *(Can't resolve 'wavesurfer.js' and related modules)*

------
https://chatgpt.com/codex/tasks/task_e_68aba8e2496483248b302da722defe88