### PR TITLE
fix: use safe pointer event detection

### DIFF
--- a/src/components/sitbackMode/sitback.logic.ts
+++ b/src/components/sitbackMode/sitback.logic.ts
@@ -93,16 +93,16 @@ if (layoutManager.mobile) {
     let lastInput = Date.now();
     let isIdle = false;
 
-    function showCursor() {
+    const showCursor = () => {
         if (isIdle) {
             isIdle = false;
             const classList = document.body.classList;
             classList.remove('mouseIdle');
             classList.remove('mouseIdle-tv');
         }
-    }
+    };
 
-    function hideCursor() {
+    const hideCursor = () => {
         if (!isIdle) {
             isIdle = true;
             const classList = document.body.classList;
@@ -112,16 +112,17 @@ if (layoutManager.mobile) {
             }
             scrollToActivePlaylistItem();
         }
-    }
+    };
 
-    function pointerActivity() {
+    const pointerActivity = () => {
         lastInput = Date.now();
         inputManager.notifyMouseMove();
         showCursor();
-    }
+    };
 
-    document.addEventListener(window.PointerEvent ? 'pointermove' : 'mousemove', pointerActivity, { passive: true });
-    document.addEventListener(window.PointerEvent ? 'pointerdown' : 'mousedown', pointerActivity, { passive: true });
+    const hasPointerEvent = 'PointerEvent' in window;
+    document.addEventListener(hasPointerEvent ? 'pointermove' : 'mousemove', pointerActivity, { passive: true });
+    document.addEventListener(hasPointerEvent ? 'pointerdown' : 'mousedown', pointerActivity, { passive: true });
 
     setInterval(() => {
         if (!isIdle && Date.now() - lastInput >= idleDelay) {


### PR DESCRIPTION
## Summary
- ensure mouse idle tracking checks pointer event support safely

## Testing
- `npm run build:production`
- `npm run build:check`
- `npm test` (fails: expected 7.0000000000021 but got 5.9999999988)
- `npm run lint` (fails: `e` is defined but never used)
- `npm run stylelint` (fails: 104 problems)


------
https://chatgpt.com/codex/tasks/task_e_68ac0253ff2883248379809dfd894e5f