### PR TITLE
refactor: extract app capabilities helper

### DIFF
--- a/src/lib/jellyfin-apiclient/ServerConnections.js
+++ b/src/lib/jellyfin-apiclient/ServerConnections.js
@@ -6,7 +6,7 @@ import { Credentials, ApiClient } from 'jellyfin-apiclient';
 import { appHost } from 'components/apphost';
 import appSettings from 'scripts/settings/appSettings';
 import { setUserInfo } from 'scripts/settings/userSettings';
-import Dashboard from 'utils/dashboard';
+import appCapabilities from 'utils/appCapabilities.ts';
 import Events from 'utils/events.ts';
 import { toApi } from 'utils/jellyfin-apiclient/compat';
 
@@ -148,7 +148,7 @@ class ServerConnections extends ConnectionManager {
 
 const credentialProvider = new Credentials();
 
-const capabilities = Dashboard.capabilities(appHost);
+const capabilities = appCapabilities(appHost);
 
 export default new ServerConnections(
     credentialProvider,

--- a/src/utils/appCapabilities.ts
+++ b/src/utils/appCapabilities.ts
@@ -1,0 +1,12 @@
+export default function capabilities(host: any) {
+    return Object.assign({
+        PlayableMediaTypes: ['Audio', 'Video'],
+        SupportedCommands: ['MoveUp', 'MoveDown', 'MoveLeft', 'MoveRight', 'PageUp', 'PageDown', 'PreviousLetter', 'NextLetter',
+            'ToggleOsd', 'ToggleContextMenu', 'Select', 'Back', 'SendKey', 'SendString', 'GoHome', 'GoToSettings', 'VolumeUp',
+            'VolumeDown', 'Mute', 'Unmute', 'ToggleMute', 'SetVolume', 'SetAudioStreamIndex', 'SetSubtitleStreamIndex',
+            'DisplayContent', 'GoToSearch', 'DisplayMessage', 'SetRepeatMode', 'SetShuffleQueue', 'ChannelUp', 'ChannelDown',
+            'PlayMediaSource', 'PlayTrailers'],
+        SupportsPersistentIdentifier: (window as any).appMode === 'cordova' || (window as any).appMode === 'android',
+        SupportsMediaControl: true
+    }, host.getPushTokenInfo());
+}

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -16,6 +16,7 @@ import DirectoryBrowser from '../components/directorybrowser/directorybrowser';
 import dialogHelper from '../components/dialogHelper/dialogHelper';
 import itemIdentifier from '../components/itemidentifier/itemidentifier';
 import { getLocationSearch } from './url.ts';
+import capabilities from './appCapabilities.ts';
 import { queryClient } from './query/queryClient';
 
 export function getCurrentUser() {
@@ -180,14 +181,7 @@ export function alert(options) {
     }
 }
 
-export function capabilities(host) {
-    return Object.assign({
-        PlayableMediaTypes: ['Audio', 'Video'],
-        SupportedCommands: ['MoveUp', 'MoveDown', 'MoveLeft', 'MoveRight', 'PageUp', 'PageDown', 'PreviousLetter', 'NextLetter', 'ToggleOsd', 'ToggleContextMenu', 'Select', 'Back', 'SendKey', 'SendString', 'GoHome', 'GoToSettings', 'VolumeUp', 'VolumeDown', 'Mute', 'Unmute', 'ToggleMute', 'SetVolume', 'SetAudioStreamIndex', 'SetSubtitleStreamIndex', 'DisplayContent', 'GoToSearch', 'DisplayMessage', 'SetRepeatMode', 'SetShuffleQueue', 'ChannelUp', 'ChannelDown', 'PlayMediaSource', 'PlayTrailers'],
-        SupportsPersistentIdentifier: window.appMode === 'cordova' || window.appMode === 'android',
-        SupportsMediaControl: true
-    }, host.getPushTokenInfo());
-}
+export { capabilities };
 
 export function selectServer() {
     if (window.NativeShell && typeof window.NativeShell.selectServer === 'function') {


### PR DESCRIPTION
## Summary
- move app capability calculation into new `appCapabilities` helper
- use `appCapabilities` in server connection setup and dashboard utilities

## Testing
- `npm test` *(fails: cardbuilder utils mismatch)*
- `npm run lint`
- `npm run build:development` *(fails: missing wavesurfer.js types and implicit any in WaveSurfer.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68acf8846acc8324ab296a02d7bcecaa