### PR TITLE
Guard header class toggling

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -60,10 +60,16 @@ build: ${__JF_BUILD_VERSION__}`);
 
     // Register handlers to update header classes
     pageClassOn('viewshow', 'standalonePage', function () {
-        document.querySelector('.skinHeader').classList.add('noHeaderRight');
+        const header = document.querySelector('.skinHeader');
+        if (header) {
+            header.classList.add('noHeaderRight');
+        }
     });
     pageClassOn('viewhide', 'standalonePage', function () {
-        document.querySelector('.skinHeader').classList.remove('noHeaderRight');
+        const header = document.querySelector('.skinHeader');
+        if (header) {
+            header.classList.remove('noHeaderRight');
+        }
     });
 
     // Initialize the api client


### PR DESCRIPTION
## Summary
- avoid errors when `.skinHeader` is missing by checking before modifying classes

## Testing
- `npm test` *(fails: cardBuilderUtils tests)*
- `npm run build:development` *(fails: cannot find module 'wavesurfer.js')*
- `node -e` script invoking header handlers without a header element

------
https://chatgpt.com/codex/tasks/task_e_68acfa8d8e4c832495c11fdcc43cc61d