### PR TITLE
Handle missing ApiClient in getCurrentUser

### DIFF
--- a/src/apps/stable/routes/user/userprofile.tsx
+++ b/src/apps/stable/routes/user/userprofile.tsx
@@ -54,7 +54,7 @@ const UserProfile: FunctionComponent = () => {
             const userImage = (page.querySelector('#image') as HTMLDivElement);
             userImage.style.backgroundImage = 'url(' + imageUrl + ')';
 
-            Dashboard.getCurrentUser().then(function (loggedInUser: UserDto) {
+            Dashboard.getCurrentUser().then(function (loggedInUser: UserDto | null) {
                 if (!user.Policy) {
                     throw new Error('Unexpected null user.Policy');
                 }

--- a/src/scripts/editorsidebar.js
+++ b/src/scripts/editorsidebar.js
@@ -308,6 +308,10 @@ $(document).on('itemsaved', '.metadataEditorPage', function (e, item) {
 }).on('pagebeforeshow', '.metadataEditorPage', function () {
     const page = this;
     Dashboard.getCurrentUser().then(function (user) {
+        if (!user) {
+            return;
+        }
+
         const id = getCurrentItemId();
         if (id) {
             ApiClient.getAncestorItems(id, user.Id).then(function (ancestors) {

--- a/src/utils/dashboard.js
+++ b/src/utils/dashboard.js
@@ -19,7 +19,13 @@ import { getLocationSearch } from './url.ts';
 import { queryClient } from './query/queryClient';
 
 export function getCurrentUser() {
-    return window.ApiClient.getCurrentUser(false);
+    const apiClient = window.ApiClient;
+
+    if (!apiClient) {
+        return Promise.resolve(null);
+    }
+
+    return apiClient.getCurrentUser(false);
 }
 
 // TODO: investigate url prefix support for serverAddress function


### PR DESCRIPTION
## Summary
- avoid crashes if `window.ApiClient` is undefined
- guard metadata editor user lookup from null
- allow null current user in user profile page

## Testing
- `npm run build:check`
- `npm test` *(fails: expected values in cardBuilderUtils tests)*
- `node -e "const fs=require('fs'); const babel=require('@babel/core'); const code=fs.readFileSync('./src/utils/dashboard.js','utf8'); const cjs=babel.transformSync(code,{plugins:['@babel/plugin-transform-modules-commonjs']}).code; const m={exports:{}}; const fn=new Function('exports','require','module','__filename','__dirname',cjs); global.window={}; fn(m.exports,()=>({}),m,'',''); m.exports.getCurrentUser().then(r=>console.log('result',r));"`


------
https://chatgpt.com/codex/tasks/task_e_68acfa9bdfe48324a34a7b03d9c8082e